### PR TITLE
[client] enum value as "type" in make_struct_for_matching

### DIFF
--- a/pyobas/signatures/signature_type.py
+++ b/pyobas/signatures/signature_type.py
@@ -22,7 +22,7 @@ class SignatureType:
     # }
     def make_struct_for_matching(self, data):
         struct = {
-            "type": self.match_policy.match_type,
+            "type": self.match_policy.match_type.value,
             "data": data,
         }
 

--- a/test/signatures/test_signature_type.py
+++ b/test/signatures/test_signature_type.py
@@ -14,7 +14,7 @@ class TestSignatureType(unittest.TestCase):
         data = "just a simple string"
         simple_struct = simple_signature_type.make_struct_for_matching(data=data)
 
-        self.assertEqual(simple_struct.get("type"), MatchTypes.MATCH_TYPE_SIMPLE)
+        self.assertEqual(simple_struct.get("type"), MatchTypes.MATCH_TYPE_SIMPLE.value)
         self.assertEqual(simple_struct.get("data"), data)
         self.assertFalse("score" in simple_struct.keys())
 
@@ -30,7 +30,7 @@ class TestSignatureType(unittest.TestCase):
         data = "just another simple string"
         simple_struct = fuzzy_signature_type.make_struct_for_matching(data=data)
 
-        self.assertEqual(simple_struct.get("type"), MatchTypes.MATCH_TYPE_FUZZY)
+        self.assertEqual(simple_struct.get("type"), MatchTypes.MATCH_TYPE_FUZZY.value)
         self.assertEqual(simple_struct.get("data"), data)
         self.assertEqual(simple_struct.get("score"), fuzzy_signature_type_score)
 
@@ -48,7 +48,7 @@ class TestSignatureType(unittest.TestCase):
         data = "just another simple string"
         simple_struct = fuzzy_signature_type.make_struct_for_matching(data=data)
 
-        self.assertEqual(simple_struct.get("type"), MatchTypes.MATCH_TYPE_FUZZY)
+        self.assertEqual(simple_struct.get("type"), MatchTypes.MATCH_TYPE_FUZZY.value)
         self.assertEqual(simple_struct.get("data"), data)
         self.assertEqual(simple_struct.get("score"), fuzzy_signature_type_score)
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* A small overlook fixed: use the string value of the enum instead of the enum item itself when creating the "struct for comparison"

Changes from:
```
{
    "type": "MatchTypes.MATCH_TYPE_FUZZY",
}
```
to:
```
{
    "type": "fuzzy",
}
```

### Related issues

* Contributes https://github.com/OpenBAS-Platform/collectors/issues/11

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
