### PR TITLE
[client] Add default period when missing a specific config (#75)

### DIFF
--- a/pyobas/daemons/collector_daemon.py
+++ b/pyobas/daemons/collector_daemon.py
@@ -4,7 +4,6 @@ import time
 from pyobas.daemons import BaseDaemon
 from pyobas.utils import PingAlive
 
-
 DEFAULT_PERIOD_SECONDS = 60
 
 

--- a/pyobas/daemons/collector_daemon.py
+++ b/pyobas/daemons/collector_daemon.py
@@ -5,6 +5,9 @@ from pyobas.daemons import BaseDaemon
 from pyobas.utils import PingAlive
 
 
+DEFAULT_PERIOD_SECONDS = 60
+
+
 class CollectorDaemon(BaseDaemon):
     """Implementation of a daemon of Collector type. Note that it requires
     specific configuration keys to run its setup.
@@ -16,6 +19,8 @@ class CollectorDaemon(BaseDaemon):
     """
 
     def _setup(self):
+        if self._configuration.get("collector_period") is None:
+            self._configuration.set("collector_period", DEFAULT_PERIOD_SECONDS)
         icon_path = self._configuration.get("collector_icon_filepath")
         icon_name = self._configuration.get("collector_id") + ".png"
         with open(icon_path, "rb") as icon_file_handle:

--- a/test/daemons/test_collector_daemon.py
+++ b/test/daemons/test_collector_daemon.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import mock_open, patch
+
+from pyobas.configuration import Configuration
+from pyobas.daemons import CollectorDaemon
+from pyobas.daemons.collector_daemon import DEFAULT_PERIOD_SECONDS
+
+
+class TestCollectorDaemon(unittest.TestCase):
+    @patch("pyobas.apis.DocumentManager.upsert")
+    @patch("pyobas.apis.CollectorManager.create")
+    @patch("builtins.open", new_callable=mock_open, read_data="data")
+    @patch("pyobas.utils.PingAlive.start")
+    def test_when_no_period_config_provided_set_default_period(
+        self,
+        mock_ping_alive,
+        mock_open_local,
+        mock_collector_create,
+        mock_document_upsert,
+    ):
+        mock_ping_alive.return_value = None
+        mock_collector_create.return_value = {}
+        mock_document_upsert.return_value = {}
+        config = Configuration(
+            config_hints={
+                "openbas_url": {"data": "fake"},
+                "openbas_token": {"data": "fake"},
+                "collector_id": {"data": "fake id"},
+            }
+        )
+        collector = CollectorDaemon(config)
+
+        collector._setup()
+
+        self.assertEqual(config.get("collector_period"), DEFAULT_PERIOD_SECONDS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a default 60 seconds period for when configuration does not provide explicit period

### Related issues

* Contributes to https://github.com/OpenBAS-Platform/collectors/issues/75

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug
