### PR TITLE
[client] fix backwards compatibility with period passed in schedule()

### DIFF
--- a/pyobas/helpers.py
+++ b/pyobas/helpers.py
@@ -290,6 +290,10 @@ class OpenBASCollectorHelper:
         }
 
     def schedule(self, message_callback, delay):
+        # backwards compatibility: when older style call sets delay
+        # and no config exists,
+        if self.__daemon._configuration.get("collector_period") is None:
+            self.__daemon._configuration.set("collector_period", delay)
         self.__daemon.set_callback(message_callback)
         self.__daemon.start()
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Missed parameter when calling `OpenBasCollectorHelper.schedule()`, inject value into configuration object as needed

### Related issues

* Contributes https://github.com/OpenBAS-Platform/collectors/issues/75


