### PR TITLE
[client] fix(configuration): correctly eval config.data to avoid falling into search path (#154)

### DIFF
--- a/pyoaev/configuration/configuration.py
+++ b/pyoaev/configuration/configuration.py
@@ -146,7 +146,12 @@ class Configuration:
             return None
 
         return self.__process_value_to_type(
-            config.data or self.__dig_config_sources_for_key(config), config.is_number
+            (
+                self.__dig_config_sources_for_key(config)
+                if config.data is None
+                else config.data
+            ),
+            config.is_number,
         )
 
     def set(self, config_key: str, value: CONFIGURATION_TYPES):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Eval of config.data to asses whteher we have a value already or if we should search for it in environment or config file was not correctly done, falling into the search path if config.data was `0` or `False` (and not just `None`)

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #154 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
