### PR TITLE
[client] fix(SCV): rename wrong domain name (#4266)

### DIFF
--- a/pyoaev/security_domain/types.py
+++ b/pyoaev/security_domain/types.py
@@ -10,7 +10,7 @@ class SecurityDomains(Enum):
         "domain_color": "#FF6666",
     }
     DATA_EXFILTRATION = {"domain_name": "Data Exfiltration", "domain_color": "#9933CC"}
-    URL_FILTERING = {"domain_name": "Url Filtering", "domain_color": "#66CCFF"}
+    URL_FILTERING = {"domain_name": "URL Filtering", "domain_color": "#66CCFF"}
     CLOUD = {"domain_name": "Cloud", "domain_color": "#9999CC"}
     TABLE_TOP = {"domain_name": "Table Top", "domain_color": "#FFCC33"}
     TOCLASSIFY = {"domain_name": "To classify", "domain_color": "#FFFFFF"}


### PR DESCRIPTION
### Proposed changes

* Rename wrong domain name

### Testing Instructions

1. Execute injectors or collectors, created payload/contracts shouldn't implement "Url Filtering" anymore.
