### PR TITLE
[clientpython] feat(contracts): add new ContractOutputType values for structured findings (#191)

### DIFF
--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -46,6 +46,19 @@ class ContractOutputType(str, Enum):
     IPv6: str = "ipv6"
     CVE: str = "cve"
     Asset: str = "asset"
+    Credentials: str = "credentials"
+    Username: str = "username"
+    Share: str = "share"
+    AdminUsername: str = "admin_username"
+    Group: str = "group"
+    Computer: str = "computer"
+    PasswordPolicy: str = "password_policy"
+    Delegation: str = "delegation"
+    Sid: str = "sid"
+    Vulnerability: str = "vulnerability"
+    AccountWithPasswordNotRequired: str = "account_with_password_not_required"
+    AsreproastableAccount: str = "asreproastable_account"
+    KerberoastableAccount: str = "kerberoastable_account"
 
 
 class ExpectationType(str, Enum):


### PR DESCRIPTION
## Summary

- Add 13 new `ContractOutputType` enum values to support structured finding extraction beyond `text` and `credentials`
- New types: `Username`, `Share`, `AdminUsername`, `Group`, `Computer`, `PasswordPolicy`, `Delegation`, `Sid`, `Vulnerability`, `AccountWithPasswordNotRequired`, `AsreproastableAccount`, `KerberoastableAccount`
- These allow injectors to produce domain-specific findings instead of generic text output

## Rationale

- **Credentials** should only represent reusable secrets (passwords, NTLM hashes, Kerberos keys)
- Kerberoasting/AS-REP roasting hashes are crackable material, not directly reusable credentials — they now have their own finding types
- Enumeration results (users, groups, shares, etc.) deserve specific types for proper filtering, display, and aggregation in the platform
- Vulnerability detections (Spooler enabled, LDAP signing not enforced, etc.) need a dedicated type separate from generic text

## Backward Compatibility

No existing enum values were removed or renamed. This is purely additive.

Closes #191