### PR TITLE
[clientpython] fix(backend): no more cookies by default (#209)

### DIFF
--- a/pyoaev/backends/backend.py
+++ b/pyoaev/backends/backend.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+from http.cookiejar import DefaultCookiePolicy
 from typing import TYPE_CHECKING, Any, BinaryIO, Dict, Optional, Union
 
 import requests
@@ -67,6 +68,7 @@ class RequestsResponse(protocol.BackendResponse):
 class RequestsBackend(protocol.Backend):
     def __init__(self, session: Optional[requests.Session] = None) -> None:
         self._client: requests.Session = session or requests.Session()
+        self._client.cookies.set_policy(DefaultCookiePolicy(allowed_domains=[]))
 
     @property
     def client(self) -> requests.Session:

--- a/test/backends/test_backend.py
+++ b/test/backends/test_backend.py
@@ -1,0 +1,11 @@
+import unittest
+
+from pyoaev.backends import backend as module
+
+
+class TestRequestsBackend(unittest.TestCase):
+    def test_no_cookie_allowed(self):
+        backend = module.RequestsBackend()
+
+        self.assertIsNotNone(backend._client.cookies._policy.allowed_domains())
+        self.assertEqual(len(backend._client.cookies._policy.allowed_domains()), 0)


### PR DESCRIPTION
### Proposed changes

* Setting the default cookie policy for `RequestsBackend` to allow only the following domains: `[]`

### Testing Instructions

```python
>>> from pyoaev.backends.backend import RequestsBackend
>>> backend = RequestsBackend()
# this request will provide in answer the cookie that is supposed to be set
>>> backend .http_request("GET", 'https://httpbin.org/cookies/set/sessioncookie/123456789').content
b'{\n  "cookies": {\n    "sessioncookie": "123456789"\n  }\n}\n'
# this request will provide in answer the cookies that were sent by the request
>>> backend .http_request("GET", 'https://httpbin.org/cookies').content
b'{\n  "cookies": {}\n}\n'
```

### Related issues

* Closes #209 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

### Further comments

Two technical suggestions for blocking cookies while keeping the shared Session object: either create a custom CookiePolicy that blocks everything or use the default one but have an empty list as the list of allowed domains.

The custom CookiePolicy seemed to have more potential side-effects + if we need to in the future we can turn the allowed_domains into a parameter that will configure the backend (while still having the empty list as default).

### Screenshots
A new test was added to check the session's cookie policy, whether is was not at None (the default that would mean accepting all) but still a len(0) (so an empty set so accept nothing).

new test before fix

<img width="1892" height="791" alt="Screenshot 2026-04-21 161039" src="https://github.com/user-attachments/assets/0a38b6bf-6044-4e19-bfd7-e69af3ba5731" />

new test after fix

<img width="1885" height="524" alt="Screenshot 2026-04-21 161216" src="https://github.com/user-attachments/assets/ddc1d2f7-d767-4b0a-a293-39e42438db1a" />
