### PR TITLE
[client-python] chore(docs): fix readthedocs (#69)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,4 @@
 ---
-# .readthedocs.yml
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
 version: 2
 
 build:
@@ -11,19 +6,10 @@ build:
   tools:
     python: "3.12"
 
-# Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
-# Optionally build your docs in additional formats such as PDF and ePub
-formats: all
-
-# Optionally set the version of Python and requirements required to build your docs
 python:
   install:
-    - requirements: requirements.txt
     - requirements: docs/requirements.txt
+    - path: .

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To learn about how to use the OpenAEV Python client and read some examples and c
 
 ### API reference
 
-To learn about the methods available for executing queries and retrieving their answers, refer to [the client API Reference](https://openaev-client-for-python.readthedocs.io/en/latest/pyoaev/pyoaev.html).
+To learn about the methods available for executing queries and retrieving their answers, refer to [the client API Reference](https://openaev-client-for-python.readthedocs.io/en/latest/autoapi/index.html).
 
 ## Tests
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,65 +1,54 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
 import os
 import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
-
-# -- Project information -----------------------------------------------------
-
 project = "OpenAEV client for Python"
 copyright = "2024, Filigran"
 author = "OpenAEV Project"
-
-# The full version, including alpha/beta/rc tags
 release = "1.10.1"
 
 master_doc = "index"
-
-autoapi_modules = {"pyoaev": {"prune": True}}
-
 pygments_style = "sphinx"
 
-# -- General configuration ---------------------------------------------------
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.inheritance_diagram",
-    "autoapi.sphinx",
+    "autoapi.extension",
     "sphinx_autodoc_typehints",
 ]
 
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
+autoapi_dirs = ["../pyoaev"]
+autoapi_options = [
+    "members",
+    "undoc-members",
+    "private-members",
+    "show-inheritance",
+]
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
+autodoc_inherit_docstrings = False
+
+# Inherited docstrings from stdlib base classes are noisy — suppress them
+_INHERITED_DOCSTRING_MARKERS = [
+    "Create a collection of name/value pairs.",  # enum.Enum
+    "str(object='') -> str",  # str
+]
+
+
+def _suppress_inherited_docstring(app, what, name, obj, options, lines):
+    """Remove inherited stdlib docstrings from generated API docs."""
+    if what == "class" and lines:
+        joined = "\n".join(lines)
+        if any(marker in joined for marker in _INHERITED_DOCSTRING_MARKERS):
+            lines.clear()
+
+
+def setup(app):
+    app.connect("autodoc-process-docstring", _suppress_inherited_docstring)
+
+
+templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-
-# -- Options for HTML output -------------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
 html_theme = "sphinx_rtd_theme"
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,7 @@
 OpenAEV client for Python
 =========================
-
 The pyoaev library is designed to help OpenAEV users and developers to interact
 with the OpenAEV platform API.
-
 The Python library requires Python >= 3.
 
 .. toctree::
@@ -11,12 +9,9 @@ The Python library requires Python >= 3.
    :caption: Contents:
 
    client_usage/getting_started.rst
-   pyoaev/pyoaev
-
 
 Indices and tables
 ==================
-
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
-autoapi==2.0.1
-sphinx==8.2.3
+sphinx==9.1.0
+sphinx-autoapi==3.4.0
+astroid==3.3.8
 sphinx-autodoc-typehints==3.2.0
-sphinx_rtd_theme==3.0.2
+sphinx_rtd_theme==3.1.0


### PR DESCRIPTION
### Proposed changes

  Fix the ReadTheDocs documentation build and restore working documentation links.

  #### Context

  The ReadTheDocs documentation was broken. A new RTD project (openaev-client-for-python) was created and configured to build the docs successfully.

  #### Changes

   - `.readthedocs.yml`: Clean up config, remove unnecessary comments and formats: all. Install the package itself (path: .) alongside doc requirements so autoapi can introspect the source.
   - `docs/conf.py`: Migrate from deprecated autoapi.sphinx to autoapi.extension, configure autoapi_dirs and autoapi_options for proper API reference generation, remove boilerplate comments.
   - `docs/requirements.txt`: Upgrade dependencies — autoapi
    2.0.1 → sphinx-autoapi 3.4.0, sphinx 8.2.3 → 9.1.0, sphinx_rtd_theme 3.0.2 → 3.1.0, add astroid 3.3.8.
   - `docs/index.rst`: Remove reference to old pyoaev/pyoaev page that no longer exists (now auto-generated by autoapi).
   - `README.md`: Update API reference link to the new autoapi URL.
   - `docs/_static/.gitkeep`: Ensure _static directory exists for the build.

  #### Working links

   - 📖 Getting started: https://openaev-client-for-python.readthedocs.io/en/latest/client_usage/getting_started.html
   - 📚 API reference: https://openaev-client-for-python.readthedocs.io/en/latest/autoapi/index.html


 ### Checklist

   - [X]  I consider the submitted work as finished
   - [X]  I tested the code for its functionality
   - [ ]  I wrote test cases for the relevant uses case
   - [X]  I added/update the relevant documentation
   - [X]  Where necessary I refactored code to improve the overall quality
   - [ ]  For bug fix → I implemented a test that covers the bug