### PR TITLE
[pyoaev] test(utils): fixing utils test (missing tenant id in log)

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -250,8 +250,13 @@ class TestUtils(unittest.TestCase):
         ping_alive.run()
         ping_alive.stop()
 
-        ping_alive.logger.info.assert_any_call("Starting PingAlive thread")
-        ping_alive.logger.info.assert_any_call("Preparing PingAlive for clean shutdown")
+        ping_alive.logger.info.assert_any_call(
+            "Starting PingAlive thread", {"tenant_id": str(ping_alive.tenant_id)}
+        )
+        ping_alive.logger.info.assert_any_call(
+            "Preparing PingAlive for clean shutdown",
+            {"tenant_id": str(ping_alive.tenant_id)},
+        )
         self.assertTrue(ping_alive.exit_event.is_set())
 
 


### PR DESCRIPTION
Fix for the testing failure on https://github.com/OpenAEV-Platform/client-python/pull/240

Root cause: drift between `main` and `release/current`.

Details:
- the multi-tenancy code was merged on `release/current` 3 weeks ago (https://github.com/OpenAEV-Platform/client-python/pull/208)
- the incriminated tests were merge into `main` 2 weeks ago, as part of the "no fix without tests" initiative combined with "fixes go into main" (https://github.com/OpenAEV-Platform/client-python/pull/213)
- resulting in a conflict after rebase of `release/current` on `main` with the now-existing tests imported from `main` not matching the codebase living on `release/current`