### PR TITLE
chore: align issue templates across repositories (#267)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,39 +1,38 @@
 ---
 name: Bug report
-about: Create a report to help us improve OpenAEV
+about: Create a bug report to help us improve the OpenAEV Python client
 title: 'fix: '
-labels: bug, needs triage
+labels: needs triage, bug
 assignees: ''
+type: bug
 
 ---
 
-Please replace every line in curly brackets { like this } with an appropriate answer, and remove this line.
-
 ## Description
 
-{ Please provide a clear and concise description of the bug. }
+<!-- Please provide a clear and concise description of the bug. -->
 
 ## Environment
 
-1. OS (where OpenCTI server runs): { e.g. Mac OS 10, Windows 10, Ubuntu 16.4, etc. }
-2. OpenCTI version: { e.g. OpenCTI 1.0.2 }
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
 3. Other environment details:
 
-## Reproducible Steps
+## Reproducible steps
 
 Steps to create the smallest reproducible scenario:
 1. { e.g. Run ... }
 2. { e.g. Click ... }
 3. { e.g. Error ... }
 
-## Expected Output
+## Expected output
 
-{ Please describe what you expected to happen. }
+<!-- Please describe what you expected to happen. -->
 
-## Actual Output
+## Actual output
 
-{ Please describe what actually happened. }
+<!-- Please describe what actually happened. -->
 
 ## Additional information
 
-{ Any additional information, including logs or screenshots if you have any. }
+<!-- Any additional information, including logs or screenshots if you have any. -->

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,22 @@
+name: Documentation request
+description: Request new or improved documentation for the OpenAEV Python client.
+title: "docs: "
+labels:
+  - needs triage
+  - documentation
+body:
+  - type: textarea
+    id: request-details
+    attributes:
+      label: Documentation request
+      description: "Please explain what you want to document or clarify."
+      placeholder: "Describe the missing documentation, unclear section, or new topic you would like to see covered."
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: "Any links, screenshots or references that help."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,26 +1,29 @@
 ---
 name: Feature request
-about: Ask for a new feature to be implemented in OpenAEV
+about: Suggest a new feature or capability for the OpenAEV Python client
 title: 'feat: '
-labels: feature, needs triage
+labels: needs triage, feature
 assignees: ''
+type: feature
 
 ---
 
-Please replace every line in curly brackets { like this } with appropriate answers, and remove this line.
+## Use case
 
-## Problem to Solve
+<!-- Please describe the use case for which you need a solution. -->
 
-{ Please describe the problem you would like to solve. }
+## Current workaround
 
-## Current Workaround
+<!-- Please describe how you currently solve or work around this problem. -->
 
-{ Please describe how you currently solve or work around this problem, given OpenAEV's limitation. }
+## Proposed solution
 
-## Proposed Solution
+<!-- Please describe the solution you would like to be provided. -->
 
-{ Please describe the solution you would like OpenAEV to provide, to solve the problem above. }
+## Additional information
 
-## Additional Information
+<!-- Any additional information, including logs or screenshots if you have any. -->
 
-{ Any additional information, including logs or screenshots if you have any. }
+## If the feature request is approved, would you be willing to submit a PR?
+
+Yes / No (help can be provided if you need assistance submitting a PR)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question about the project
+about: Ask a question about the OpenAEV Python client
 title: ''
 labels: needs triage, question
 assignees: ''
@@ -16,6 +16,12 @@ assignees: ''
 ## Description
 
 <!-- Please provide a clear and concise description of your question. -->
+
+## Environment
+
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
 ## Additional information
 


### PR DESCRIPTION
## Summary

Aligns the issue templates across all Filigran repositories (identical bug / feature / question + a security vulnerability link), adds a documentation request template where the repo ships docs, and keeps client-python templates where applicable.

Closes #267