### PR TITLE
chore: audit & align issue templates (#269)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # pyoaev
 config.yml
+!.github/ISSUE_TEMPLATE/config.yml
 exports
 logs
 __test__.py


### PR DESCRIPTION
## Summary

Audits and aligns the GitHub issue templates in `.github/ISSUE_TEMPLATE/` with the canonical Filigran set for the OpenAEV Python client:

- `bug_report.md`, `feature_request.md`, `question.md` — already aligned (verified)
- `documentation.yaml` — kept (this repo ships docs)
- `config.yml` — added with public default (`blank_issues_enabled: true`)
- `.gitignore` — added a surgical negation so the issue-template `config.yml` is tracked (the broad `config.yml` ignore is intended for the `pyoaev` runtime config)

No security `contact_link` is added: this is a public repo with native private vulnerability reporting, so a link would duplicate the built-in report button. No community Slack links or stray/duplicate templates present.

Closes #269