### PR TITLE
feat(pyoaev): introduce the vulnerability endpoint (#197)

### DIFF
--- a/pyoaev/apis/__init__.py
+++ b/pyoaev/apis/__init__.py
@@ -17,5 +17,6 @@ from .signature import *  # noqa: F401,F403
 from .tag import *  # noqa: F401,F403
 from .team import *  # noqa: F401,F403
 from .user import *  # noqa: F401,F403
+from .vulnerability import *  # noqa: F401,F403
 
 __all__ = [name for name in dir() if not name.startswith("_")]

--- a/pyoaev/apis/vulnerability.py
+++ b/pyoaev/apis/vulnerability.py
@@ -7,6 +7,7 @@ from pyoaev.base import RESTManager, RESTObject
 class Vulnerability(RESTObject):
     _id_attr = "vulnerability_id"
 
+
 class VulnerabilityManager(RESTManager):
     _path = "/vulnerabilities"
 

--- a/pyoaev/apis/vulnerability.py
+++ b/pyoaev/apis/vulnerability.py
@@ -1,0 +1,17 @@
+from typing import Any, Dict
+
+from pyoaev import exceptions as exc
+from pyoaev.base import RESTManager, RESTObject
+
+
+class Vulnerability(RESTObject):
+    _id_attr = "vulnerability_id"
+
+class VulnerabilityManager(RESTManager):
+    _path = "/vulnerabilities"
+
+    @exc.on_http_error(exc.OpenAEVUpdateError)
+    def upsert(self, data: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
+        path = f"{self.path}/bulk"
+        result = self.openaev.http_post(path, post_data=data, **kwargs)
+        return result


### PR DESCRIPTION
### Proposed changes

* Introduced a new `VulnerabilityManager` targeting the `/vulnerabilities` endpoint.
* Added support for bulk vulnerability upsert operations through `/vulnerabilities/bulk`.
* Kept the implementation aligned with the existing CVE (legacy).

### Related issues

* Closes #197
* Issue #292

### Checklist

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

This PR intentionally maintains the same scope and implementation model as the existing CVE client.

A separate issue, `feat(pyoaev): analysis and impact of api endpoint realignment`, will be created to evaluate all API endpoints that are not currently exposed by `pyoaev`.

The goal is to determine whether all endpoints should be made available users via client-python (pyoaev) and to assess the technical and functional impact of any further realignment before implementing any additional changes.
