### PR TITLE
feat(contracts): adding the new availableExpectations field (#304)

### DIFF
--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -281,7 +281,7 @@ class ContractAttachment(ContractCardinalityElement):
 
 @dataclass
 class ContractExpectations(ContractCardinalityElement):
-    cardinality = ContractCardinality.Multiple
+    cardinality: str = ContractCardinality.Multiple
     predefinedExpectations: List[Expectation] = field(default_factory=list)
     availableExpectations: List[Expectation] = field(default_factory=list)
 

--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -284,7 +284,6 @@ class ContractAttachment(ContractCardinalityElement):
 @dataclass
 class ContractExpectations(ContractCardinalityElement):
     cardinality: str = ContractCardinality.Multiple
-    predefinedExpectations: List[Expectation] = field(default_factory=list)
     availableExpectations: List[Expectation] = field(default_factory=list)
 
     @property

--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -80,6 +80,8 @@ class Expectation:
     expectation_description: str
     expectation_score: int
     expectation_expectation_group: bool
+    expectation_is_predefined: bool = False
+    expectation_is_multi_selectable: bool = False
 
 
 @dataclass

--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -283,6 +283,7 @@ class ContractAttachment(ContractCardinalityElement):
 class ContractExpectations(ContractCardinalityElement):
     cardinality = ContractCardinality.Multiple
     predefinedExpectations: List[Expectation] = field(default_factory=list)
+    availableExpectations: List[Expectation] = field(default_factory=list)
 
     @property
     def get_type(self) -> str:


### PR DESCRIPTION
### Proposed changes

* Adding new field `availableExpectations` to `ContractExpectations`

### Testing Instructions

1. Need to be tested through an updated injector rather than as a stand-alone

### Related issues

* Closes #304 
* Closes #305 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
