### PR TITLE
feat(pyoaev): adapt endpoint and AI target APIs to the asset taxonomy remodel (#307)

### DIFF
--- a/pyoaev/apis/ai_target.py
+++ b/pyoaev/apis/ai_target.py
@@ -24,7 +24,7 @@ class AiTargetManager(
             "ai_target_model",
             "ai_target_modality",
             "ai_target_system_prompt",
-            "ai_target_api_key_variable",
+            "ai_target_token",
             "ai_target_configuration",
         ),
     )

--- a/pyoaev/apis/endpoint.py
+++ b/pyoaev/apis/endpoint.py
@@ -13,7 +13,7 @@ class Endpoint(RESTObject):
 class EndpointManager(RESTManager):
     _path = "/endpoints"
     _obj_cls = Endpoint
-    # asset_name is the only required attribute. Everything else - including endpoint_hostname,
+    # asset_name is the only required attribute. Everything else - including asset_hostname,
     # endpoint_platform and endpoint_arch - is optional: agents and collectors typically provide
     # the endpoint fields, while category-driven assets (web app, cloud, network, ...) may omit
     # them and the backend defaults endpoint_platform / endpoint_arch to "Unknown".

--- a/pyoaev/apis/endpoint.py
+++ b/pyoaev/apis/endpoint.py
@@ -20,12 +20,12 @@ class EndpointManager(RESTManager):
     _create_attrs = RequiredOptional(
         required=("asset_name",),
         optional=(
-            "endpoint_hostname",
+            "asset_hostname",
             "endpoint_platform",
             "endpoint_arch",
-            "endpoint_ips",
-            "endpoint_mac_addresses",
-            "endpoint_url",
+            "asset_ips",
+            "asset_mac_addresses",
+            "asset_url",
             "asset_description",
             "asset_external_reference",
             "asset_tags",

--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -29,6 +29,7 @@ class ContractFieldType(str, Enum):
     Expectation: str = "expectation"
     Asset: str = "asset"
     AssetGroup: str = "asset-group"
+    AiTarget: str = "ai-target"
     Payload: str = "payload"
 
 
@@ -314,6 +315,21 @@ class ContractAssetGroup(ContractCardinalityElement):
     @property
     def get_type(self) -> str:
         return ContractFieldType.AssetGroup.value
+
+
+@dataclass
+class ContractAiTarget(ContractCardinalityElement):
+    """Selector for a pre-configured AiTarget asset (LLM endpoint / AI agent under test).
+
+    Renders in the UI as an entity autocomplete (backed by the platform ``/ai_targets``
+    options endpoint), analogous to the asset / asset group pickers. The selected value is
+    the AiTarget id, resolved by the executing injector at run time. Unlike ``ContractAsset``
+    the key is free-form so a contract can name the field as it wishes.
+    """
+
+    @property
+    def get_type(self) -> str:
+        return ContractFieldType.AiTarget.value
 
 
 @dataclass

--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -323,8 +323,9 @@ class ContractAiTarget(ContractCardinalityElement):
 
     Renders in the UI as an entity autocomplete (backed by the platform ``/ai_targets``
     options endpoint), analogous to the asset / asset group pickers. The selected value is
-    the AiTarget id, resolved by the executing injector at run time. Unlike ``ContractAsset``
-    the key is free-form so a contract can name the field as it wishes.
+    the AI target's ``asset_id`` (AI targets are AI_TARGET-category assets, see
+    ``AiTarget._id_attr``), resolved by the executing injector at run time. Unlike
+    ``ContractAsset`` the key is free-form so a contract can name the field as it wishes.
     """
 
     @property

--- a/test/apis/endpoint/test_endpoint.py
+++ b/test/apis/endpoint/test_endpoint.py
@@ -61,7 +61,7 @@ class TestEndpointCategorization(TestCase):
             "asset_name": "Filigran website",
             "asset_category": AssetCategory.WEB_APPLICATION,
             "asset_subcategory": AssetSubCategory.WEBSITE,
-            "endpoint_url": "https://filigran.io",
+            "asset_url": "https://filigran.io",
             "asset_internet_facing": True,
         }
 


### PR DESCRIPTION
## Summary

Adapts pyoaev to the OpenAEV asset taxonomy remodel (OpenAEV-Platform/openaev#6704), where AiTarget is merged into Asset and network fields move to the asset level:

- EndpointManager create/upsert attributes now send asset_hostname / asset_ips / asset_mac_addresses / asset_url (endpoint_platform / endpoint_arch stay endpoint-scoped), matching the backend EndpointInput wire names.
- AiTargetManager identifies AI targets by asset_id and sends asset_name + ai_target_* attributes against the /ai_targets facade; the credential attribute is renamed ai_target_api_key_variable -> ai_target_token to match the backend AiTargetInput.
- New ContractAiTarget contract field type (ai-target) so injector contracts can render a platform AI target picker instead of a free-text ID field; its docstring clarifies the selected value is the AI target's asset_id.
- Tests updated to the renamed keys (160 tests green).

BREAKING CHANGE: consumers building endpoint payloads with the old endpoint_hostname / endpoint_ips / endpoint_mac_addresses / endpoint_url keys must switch to the asset_* keys, and ai_target_api_key_variable must become ai_target_token. Requires an OpenAEV backend that includes the asset taxonomy remodel.

Closes #307

## Test plan

- [x] python -m pytest (160 passed)
- [x] isort --check-only . and black --check . clean locally; CircleCI ensure_formatting / linter / test / build green
- [ ] Smoke test an injector/collector using this branch against a remodeled OpenAEV instance
