### PR TITLE
fix(contracts): emit predefinedExpectations from availableExpectations (#309)

### DIFF
--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -285,7 +285,25 @@ class ContractAttachment(ContractCardinalityElement):
 @dataclass
 class ContractExpectations(ContractCardinalityElement):
     cardinality: str = ContractCardinality.Multiple
+    # Full set the user may choose from in the "add expectation" picker.
     availableExpectations: List[Expectation] = field(default_factory=list)
+    # Subset pre-filled by default when the inject / atomic testing is created.
+    # The OpenAEV platform reads this field-level array (not the per-expectation
+    # flag) to pre-populate expectations, so it must be emitted in the contract.
+    predefinedExpectations: List[Expectation] = field(default_factory=list)
+
+    def __post_init__(self):
+        super().__post_init__()
+        # When the caller did not pass an explicit predefined list, derive it from
+        # the expectations flagged predefined in the available set. This keeps the
+        # ergonomic single-list API (flag each Expectation with
+        # expectation_is_predefined=True) working end-to-end on the platform.
+        if not self.predefinedExpectations and self.availableExpectations:
+            self.predefinedExpectations = [
+                expectation
+                for expectation in self.availableExpectations
+                if getattr(expectation, "expectation_is_predefined", False)
+            ]
 
     @property
     def get_type(self) -> str:

--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -2,7 +2,7 @@ import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from pyoaev import utils
 from pyoaev.contracts.contract_utils import ContractCardinality, ContractVariable
@@ -290,7 +290,10 @@ class ContractExpectations(ContractCardinalityElement):
     # Subset pre-filled by default when the inject / atomic testing is created.
     # The OpenAEV platform reads this field-level array (not the per-expectation
     # flag) to pre-populate expectations, so it must be emitted in the contract.
-    predefinedExpectations: List[Expectation] = field(default_factory=list)
+    # None means "not provided": the list is then derived from the expectations
+    # flagged expectation_is_predefined=True. Pass an explicit list (possibly
+    # empty) to override the derivation.
+    predefinedExpectations: Optional[List[Expectation]] = None
 
     def __post_init__(self):
         super().__post_init__()
@@ -298,11 +301,11 @@ class ContractExpectations(ContractCardinalityElement):
         # the expectations flagged predefined in the available set. This keeps the
         # ergonomic single-list API (flag each Expectation with
         # expectation_is_predefined=True) working end-to-end on the platform.
-        if not self.predefinedExpectations and self.availableExpectations:
+        if self.predefinedExpectations is None:
             self.predefinedExpectations = [
                 expectation
                 for expectation in self.availableExpectations
-                if getattr(expectation, "expectation_is_predefined", False)
+                if expectation.expectation_is_predefined
             ]
 
     @property

--- a/test/contracts/test_contract_expectations.py
+++ b/test/contracts/test_contract_expectations.py
@@ -72,6 +72,25 @@ class TestContractExpectations(unittest.TestCase):
             [e["expectation_type"] for e in data["predefinedExpectations"]],
         )
 
+    def test_explicit_empty_list_overrides_flags(self):
+        """
+        An explicit empty ``predefinedExpectations`` list must suppress the
+        derivation even when some available expectations carry the predefined
+        flag, while still serializing as an (empty) array.
+        """
+        field = ContractExpectations(
+            key="expectations",
+            label="Expectations",
+            availableExpectations=[
+                _expectation(ExpectationType.detection, "Detection", True),
+            ],
+            predefinedExpectations=[],
+        )
+
+        data = _serialize(field)
+
+        self.assertEqual([], data["predefinedExpectations"])
+
     def test_no_flag_yields_no_predefined(self):
         field = ContractExpectations(
             key="expectations",

--- a/test/contracts/test_contract_expectations.py
+++ b/test/contracts/test_contract_expectations.py
@@ -1,0 +1,90 @@
+import json
+import unittest
+
+from pyoaev import utils
+from pyoaev.contracts.contract_config import (
+    ContractCardinality,
+    ContractExpectations,
+    Expectation,
+    ExpectationType,
+)
+
+
+def _expectation(expectation_type, name, is_predefined):
+    return Expectation(
+        expectation_type=expectation_type,
+        expectation_name=name,
+        expectation_description="",
+        expectation_score=100,
+        expectation_expectation_group=False,
+        expectation_is_predefined=is_predefined,
+    )
+
+
+def _serialize(field):
+    return json.loads(json.dumps(field, cls=utils.EnhancedJSONEncoder))
+
+
+class TestContractExpectations(unittest.TestCase):
+    def test_predefined_derived_from_flag(self):
+        """
+        The platform pre-fills expectations from the field-level
+        ``predefinedExpectations`` array, so it must be populated from the
+        expectations flagged ``expectation_is_predefined=True``.
+        """
+        field = ContractExpectations(
+            key="expectations",
+            label="Expectations",
+            cardinality=ContractCardinality.Multiple,
+            availableExpectations=[
+                _expectation(ExpectationType.detection, "Detection", True),
+                _expectation(ExpectationType.prevention, "Prevention", True),
+                _expectation(ExpectationType.vulnerability, "Not vulnerable", False),
+            ],
+        )
+
+        data = _serialize(field)
+
+        self.assertEqual("expectation", data["type"])
+        self.assertEqual(
+            ["DETECTION", "PREVENTION", "VULNERABILITY"],
+            [e["expectation_type"] for e in data["availableExpectations"]],
+        )
+        # Only the flagged ones are pre-filled.
+        self.assertEqual(
+            ["DETECTION", "PREVENTION"],
+            [e["expectation_type"] for e in data["predefinedExpectations"]],
+        )
+
+    def test_explicit_predefined_is_kept(self):
+        detection = _expectation(ExpectationType.detection, "Detection", False)
+        field = ContractExpectations(
+            key="expectations",
+            label="Expectations",
+            availableExpectations=[detection],
+            predefinedExpectations=[detection],
+        )
+
+        data = _serialize(field)
+
+        self.assertEqual(
+            ["DETECTION"],
+            [e["expectation_type"] for e in data["predefinedExpectations"]],
+        )
+
+    def test_no_flag_yields_no_predefined(self):
+        field = ContractExpectations(
+            key="expectations",
+            label="Expectations",
+            availableExpectations=[
+                _expectation(ExpectationType.vulnerability, "Not vulnerable", False),
+            ],
+        )
+
+        data = _serialize(field)
+
+        self.assertEqual([], data["predefinedExpectations"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #309

## Summary

Predefined Detection / Prevention (and other) expectations stopped pre-filling when creating an atomic testing or inject: the expectations picker no longer proposed any defaults.

Commit 3ca50c3 (#306) renamed `ContractExpectations.predefinedExpectations` to `availableExpectations` and introduced a per-expectation `expectation_is_predefined` flag. But the OpenAEV platform pre-fills expectations from the field-level `predefinedExpectations` array (the frontend inject form reads `predefinedExpectations` for the defaults and `availableExpectations` for the picker); the per-expectation flag is not consumed. After #306 pyoaev emitted only `availableExpectations`, so `predefinedExpectations` was always empty and nothing was pre-filled.

This is on unreleased `main` (not in 2.260717.0), so it would ship as a regression on the next release and break predefined expectations for every Python injector.

## Change

- `ContractExpectations` now carries both `availableExpectations` (the full selectable set) and `predefinedExpectations` (the defaults the platform pre-fills).
- `predefinedExpectations` defaults to `None` as the "not provided" sentinel: when the caller does not pass it, `__post_init__` derives it from the expectations flagged `expectation_is_predefined=True`, so the existing single-list API keeps working end-to-end. Passing an explicit list (including an empty one) overrides the derivation, and the serialized contract always emits an array.
- Added unit tests under `test/contracts/` covering the derivation, an explicit predefined list, the explicit-empty-list override, and the no-flag case.

## Test plan

- `pytest test/contracts/` passes (4 tests).
- `black` / `isort` clean.
- Verified serialization via `EnhancedJSONEncoder` emits a `predefinedExpectations` array matching the flagged expectations.
