### PR TITLE
feat(pyoaev): transport source-declared injector_author on registration (#311)

### DIFF
--- a/pyoaev/apis/injector.py
+++ b/pyoaev/apis/injector.py
@@ -22,5 +22,9 @@ class InjectorManager(GetMixin, ListMixin, CreateMixin, UpdateMixin, RESTManager
             "injector_category",
             "injector_executor_commands",
             "injector_executor_clear_commands",
+            # Publisher/author of the injector's contracts, declared in the
+            # connector source code (not user config). The platform attributes
+            # every contract of this injector to an organization of this name.
+            "injector_author",
         ),
     )

--- a/pyoaev/helpers.py
+++ b/pyoaev/helpers.py
@@ -340,6 +340,8 @@ class OpenAEVInjectorHelper:
             "injector_executor_clear_commands": config.get_conf(
                 "injector_executor_clear_commands", default=None
             ),
+            # Publisher/author of the injector's contracts (source-declared).
+            "injector_author": config.get_conf("injector_author", default=None),
         }
 
         self.logger_class = utils.logger(


### PR DESCRIPTION
## Related issue

Closes #311

## Summary

- Add injector_author to the injector registration payload (InjectorManager attribute allow-list).
- OpenAEVInjectorHelper reads injector_author from the connector configuration (source-declared, default None) and sends it at registration.

The platform (OpenAEV-Platform/openaev#6784) attributes every contract of the injector to an organization of this name; when absent it derives the author from the injector name, so this change is fully backward compatible.