### PR TITLE
feat(contracts): declare expected security platform types on expectations (#313)

### DIFF
--- a/pyoaev/__init__.py
+++ b/pyoaev/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.260717.0"
+__version__ = "2.260720.0"
 
 from pyoaev._version import (  # noqa: F401
     __author__,

--- a/pyoaev/__init__.py
+++ b/pyoaev/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.260720.0"
+__version__ = "2.260717.0"
 
 from pyoaev._version import (  # noqa: F401
     __author__,

--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -74,6 +74,24 @@ class ExpectationType(str, Enum):
     vulnerability: str = "VULNERABILITY"
 
 
+class SecurityPlatformType(str, Enum):
+    """Categories of security platform expected to fulfil a technical expectation.
+
+    When an expectation declares one or more of these, the platform focuses the
+    detection/prevention result on collectors of those types only (instead of every
+    connected security platform). An empty list means "any security platform".
+    """
+
+    EDR: str = "EDR"
+    XDR: str = "XDR"
+    SIEM: str = "SIEM"
+    SOAR: str = "SOAR"
+    NDR: str = "NDR"
+    ISPM: str = "ISPM"
+    LLM_FIREWALL: str = "LLM_FIREWALL"
+    AI_GATEWAY: str = "AI_GATEWAY"
+
+
 @dataclass
 class Expectation:
     expectation_type: ExpectationType
@@ -83,6 +101,12 @@ class Expectation:
     expectation_expectation_group: bool
     expectation_is_predefined: bool = False
     expectation_is_multi_selectable: bool = False
+    # Security platform types expected to fulfil this expectation. Empty = any
+    # platform (unchanged behaviour). Typically set for DETECTION / PREVENTION,
+    # left empty for MANUAL expectations.
+    expectation_expected_security_platform_types: List[SecurityPlatformType] = field(
+        default_factory=list
+    )
 
 
 @dataclass

--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -78,8 +78,9 @@ class SecurityPlatformType(str, Enum):
     """Categories of security platform expected to fulfil a technical expectation.
 
     When an expectation declares one or more of these, the platform focuses the
-    detection/prevention result on collectors of those types only (instead of every
-    connected security platform). An empty list means "any security platform".
+    technical (DETECTION / PREVENTION / VULNERABILITY) result on collectors of
+    those types only (instead of every connected security platform). An empty
+    list means "any security platform".
     """
 
     EDR: str = "EDR"
@@ -102,8 +103,8 @@ class Expectation:
     expectation_is_predefined: bool = False
     expectation_is_multi_selectable: bool = False
     # Security platform types expected to fulfil this expectation. Empty = any
-    # platform (unchanged behaviour). Typically set for DETECTION / PREVENTION,
-    # left empty for MANUAL expectations.
+    # platform (unchanged behaviour). Typically set for technical expectations
+    # (DETECTION / PREVENTION / VULNERABILITY), left empty for MANUAL ones.
     expectation_expected_security_platform_types: List[SecurityPlatformType] = field(
         default_factory=list
     )

--- a/test/contracts/test_contract_expectations.py
+++ b/test/contracts/test_contract_expectations.py
@@ -7,10 +7,11 @@ from pyoaev.contracts.contract_config import (
     ContractExpectations,
     Expectation,
     ExpectationType,
+    SecurityPlatformType,
 )
 
 
-def _expectation(expectation_type, name, is_predefined):
+def _expectation(expectation_type, name, is_predefined, expected_platforms=None):
     return Expectation(
         expectation_type=expectation_type,
         expectation_name=name,
@@ -18,6 +19,7 @@ def _expectation(expectation_type, name, is_predefined):
         expectation_score=100,
         expectation_expectation_group=False,
         expectation_is_predefined=is_predefined,
+        expectation_expected_security_platform_types=expected_platforms or [],
     )
 
 
@@ -103,6 +105,59 @@ class TestContractExpectations(unittest.TestCase):
         data = _serialize(field)
 
         self.assertEqual([], data["predefinedExpectations"])
+
+    def test_expected_security_platform_types_default_empty(self):
+        """An expectation without declared platforms serializes an empty list."""
+        field = ContractExpectations(
+            key="expectations",
+            label="Expectations",
+            availableExpectations=[
+                _expectation(ExpectationType.detection, "Detection", True),
+            ],
+        )
+
+        data = _serialize(field)
+
+        self.assertEqual(
+            [],
+            data["availableExpectations"][0][
+                "expectation_expected_security_platform_types"
+            ],
+        )
+
+    def test_expected_security_platform_types_serialize(self):
+        """Declared platform types serialize as their string values on both
+        the available and predefined arrays."""
+        field = ContractExpectations(
+            key="expectations",
+            label="Expectations",
+            availableExpectations=[
+                _expectation(
+                    ExpectationType.detection,
+                    "Detection",
+                    True,
+                    expected_platforms=[
+                        SecurityPlatformType.EDR,
+                        SecurityPlatformType.XDR,
+                    ],
+                ),
+            ],
+        )
+
+        data = _serialize(field)
+
+        self.assertEqual(
+            ["EDR", "XDR"],
+            data["availableExpectations"][0][
+                "expectation_expected_security_platform_types"
+            ],
+        )
+        self.assertEqual(
+            ["EDR", "XDR"],
+            data["predefinedExpectations"][0][
+                "expectation_expected_security_platform_types"
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/test/contracts/test_contract_expectations.py
+++ b/test/contracts/test_contract_expectations.py
@@ -12,6 +12,11 @@ from pyoaev.contracts.contract_config import (
 
 
 def _expectation(expectation_type, name, is_predefined, expected_platforms=None):
+    # Only pass the field when declared so the default (None) path exercises
+    # the dataclass default_factory instead of an explicit empty list.
+    kwargs = {}
+    if expected_platforms is not None:
+        kwargs["expectation_expected_security_platform_types"] = expected_platforms
     return Expectation(
         expectation_type=expectation_type,
         expectation_name=name,
@@ -19,7 +24,7 @@ def _expectation(expectation_type, name, is_predefined, expected_platforms=None)
         expectation_score=100,
         expectation_expectation_group=False,
         expectation_is_predefined=is_predefined,
-        expectation_expected_security_platform_types=expected_platforms or [],
+        **kwargs,
     )
 
 


### PR DESCRIPTION
## Goal

Closes #313.

Add an optional `expectation_expected_security_platform_types` field and a `SecurityPlatformType` enum (EDR, XDR, SIEM, SOAR, NDR, ISPM, LLM_FIREWALL, AI_GATEWAY) to the contract `Expectation` dataclass.

## Why

On OpenAEV, technical expectations (DETECTION / PREVENTION / VULNERABILITY) are pre-seeded with a pending result for every connected security platform, so the target-results view lists all of them. Letting a contract declare which security platform TYPES are expected to fulfil an expectation lets the platform focus the technical results on the relevant platforms only.

## Behaviour

- The field is optional and defaults to an empty list.
- Empty list means any security platform (unchanged behaviour); typically empty for MANUAL expectations.
- It serializes on both `availableExpectations` and the derived `predefinedExpectations`.

## Changes

- `pyoaev/contracts/contract_config.py`: `SecurityPlatformType` enum + `expectation_expected_security_platform_types` field on `Expectation`.
- Tests for default-empty and serialization on both arrays.

No manual version bump: the version is bumped automatically by the release process.

## Test plan

- `pytest test/contracts/` passes (6 tests).
- `black` / `isort` clean.
- Enum values verified against `SecurityPlatform.SECURITY_PLATFORM_TYPE` in openaev-model and the field name against the `expectation_expected_security_platform_types` JsonProperty on the framework `Expectation` form.

This is the blocking library change for the platform + injectors rework.
