### PR TITLE
fix(expectations): tolerate null inject_expectation_signatures

### DIFF
--- a/pyoaev/apis/inject_expectation/model/expectation.py
+++ b/pyoaev/apis/inject_expectation/model/expectation.py
@@ -1,8 +1,8 @@
 from enum import Enum
-from typing import List
+from typing import Any, List
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 from thefuzz import fuzz
 
 from pyoaev.signatures.signature_type import SignatureType
@@ -41,10 +41,20 @@ class Expectation(BaseModel):
     """
 
     inject_expectation_id: UUID
-    inject_expectation_signatures: List[ExpectationSignature]
+    inject_expectation_signatures: List[ExpectationSignature] = Field(
+        default_factory=list
+    )
 
     success_label: str = "Success"
     failure_label: str = "Failure"
+
+    @field_validator("inject_expectation_signatures", mode="before")
+    @classmethod
+    def _coerce_none_signatures_to_empty(cls, value: Any) -> Any:
+        # The platform serializes this field as null when an expectation has no
+        # signatures yet. Without this, a single such expectation raises a
+        # ValidationError that aborts the whole batch fetch (collectors#490).
+        return [] if value is None else value
 
     def __init__(self, *a, **kw):
         super().__init__(*a, **kw)

--- a/test/apis/expectation/test_expectation.py
+++ b/test/apis/expectation/test_expectation.py
@@ -333,6 +333,43 @@ class TestExpectation(unittest.TestCase):
 
         self.assertFalse(matched)
 
+    def test_when_signatures_is_none_it_is_coerced_to_empty_list(self):
+        # The platform may serialize inject_expectation_signatures as null; parsing
+        # must not raise, otherwise a single such expectation aborts the whole
+        # batch fetch (collectors#490).
+        for model_cls in (DetectionExpectation, PreventionExpectation):
+            model = model_cls(
+                **{
+                    "inject_expectation_id": uuid4(),
+                    "inject_expectation_signatures": None,
+                },
+                api_client=create_mock_api_client(),
+            )
+            self.assertEqual(model.inject_expectation_signatures, [])
+
+    def test_when_signatures_is_missing_it_defaults_to_empty_list(self):
+        model = DetectionExpectation(
+            **{"inject_expectation_id": uuid4()},
+            api_client=create_mock_api_client(),
+        )
+        self.assertEqual(model.inject_expectation_signatures, [])
+
+    def test_when_signatures_provided_they_are_preserved(self):
+        model = DetectionExpectation(
+            **{
+                "inject_expectation_id": uuid4(),
+                "inject_expectation_signatures": [
+                    {
+                        "type": SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME,
+                        "value": "parent.exe",
+                    },
+                ],
+            },
+            api_client=create_mock_api_client(),
+        )
+        self.assertEqual(len(model.inject_expectation_signatures), 1)
+        self.assertEqual(model.inject_expectation_signatures[0].value, "parent.exe")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The SentinelOne collector (and any collector polling detection/prevention expectations) stops processing with:

```
ERROR [CollectorExpectationManager] Error fetching expectations: 1 validation error for PreventionExpectation
inject_expectation_signatures
  Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
```

The collector logs `Fetched 0 expectations` and never matches any alert.

Ref: OpenAEV-Platform/collectors#490

## Root cause

`Expectation.inject_expectation_signatures` was declared as a required, non-nullable `List[ExpectationSignature]`. The platform serializes this field as `null` when an expectation has no computed signatures. Because `expectations_models_for_source` builds every model in a single loop, **one** such expectation raises a `ValidationError` that aborts the **entire** batch fetch — so even valid expectations are never returned.

## Fix

- `inject_expectation_signatures` now defaults to an empty list and a `mode="before"` validator coerces `null` → `[]`.
- A single signature-less expectation is parsed as having no signatures instead of crashing the whole batch.

## Tests

- Added regression tests: `null` → `[]`, missing key → `[]`, provided signatures preserved.
- Full suite green (`169 passed`), `black`/`isort` clean, no new `mypy` errors on the changed file.

## Note

This makes the client resilient to `null` signatures (stops the crash / batch abort). It does **not** by itself make alerts validate when signatures are genuinely empty — matching requires non-empty signatures, which is a platform-side concern (why signatures are null on the affected environment is being investigated separately).