### PR TITLE
feat(collector): support collector_author override on registration (#317)

### DIFF
--- a/pyoaev/apis/collector.py
+++ b/pyoaev/apis/collector.py
@@ -19,7 +19,13 @@ class CollectorManager(GetMixin, ListMixin, CreateMixin, UpdateMixin, RESTManage
             "collector_name",
             "collector_type",
             "collector_period",
-        )
+        ),
+        optional=(
+            "collector_security_platform",
+            # Source-declared author override for the collector's payloads and
+            # contracts. When absent, the platform uses the collector name.
+            "collector_author",
+        ),
     )
 
     @exc.on_http_error(exc.OpenAEVUpdateError)

--- a/pyoaev/configuration/settings_loader.py
+++ b/pyoaev/configuration/settings_loader.py
@@ -129,3 +129,8 @@ class ConfigLoaderCollector(BaseConfigModel):
     icon_filepath: str | None = Field(
         description="Path to the icon file of the collector.",
     )
+    author: str | None = Field(
+        default=None,
+        description="Optional author override for the connector's payloads and contracts. "
+        "When absent, the platform attributes them to the connector's name.",
+    )

--- a/pyoaev/daemons/collector_daemon.py
+++ b/pyoaev/daemons/collector_daemon.py
@@ -16,6 +16,9 @@ class CollectorDaemon(BaseDaemon):
     `collector_period`: time to wait in seconds between each loop execution; note
     that this time is added to the time the loop takes to run, so the actual total
     time between each loop start is time_of_loop+period.
+    `collector_author` (optional): source-declared author override for the
+    collector's payloads and contracts; when absent, the platform attributes
+    them to the collector's name.
     """
 
     def __init__(
@@ -62,6 +65,9 @@ class CollectorDaemon(BaseDaemon):
                 "collector_type": self.collector_type,
                 "collector_period": self._configuration.get("collector_period"),
                 "collector_security_platform": security_platform_id,
+                # Optional author override; None lets the platform fall back to
+                # the collector name.
+                "collector_author": self._configuration.get("collector_author"),
             }
         with open(icon_path, "rb") as icon_file_handle:
             collector_icon = (icon_name, icon_file_handle, "image/png")


### PR DESCRIPTION
### Proposed changes

* Declare the optional `collector_author` attribute on `CollectorManager` create attrs,
  mirroring the existing `injector_author` support on `InjectorManager`.
* Forward the optional `collector_author` configuration key in the registration payload
  built by `CollectorDaemon._setup()`. When the key is not configured it resolves to
  `None` and the platform keeps its name-based author fallback.
* Document the new optional key in the `CollectorDaemon` docstring.

This lets a collector whose display name is not a good author declare a proper author
for its payloads and arsenal contracts, while the default remains the collector name
(never a generic default like "Filigran").

### Testing Instructions

1. Run any collector without `collector_author`: payloads keep being authored by the
   collector's name (platform-side fallback, unchanged behavior).
2. Set `collector_author` in a collector's configuration hints and restart it: newly
   upserted payloads are authored by the declared author organization.

### Related issues

* Closes #317
