### PR TITLE
feat(contracts): add file output type (#329)

### DIFF
--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -50,6 +50,7 @@ class ContractOutputType(str, Enum):
     Credentials: str = "credentials"
     Username: str = "username"
     Share: str = "share"
+    File: str = "file"
     AdminUsername: str = "admin_username"
     Group: str = "group"
     Computer: str = "computer"

--- a/test/contracts/test_contract_output_types.py
+++ b/test/contracts/test_contract_output_types.py
@@ -1,0 +1,15 @@
+import unittest
+
+from pyoaev.contracts.contract_config import ContractOutputType
+
+
+class ContractOutputTypeTest(unittest.TestCase):
+    def test_file_wire_label(self):
+        # The wire label is a public contract shared with the platform enum and every
+        # injector that declares a `file` output; it must stay exactly "file".
+        self.assertEqual(ContractOutputType.File.value, "file")
+        self.assertEqual(ContractOutputType.File, "file")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #329

Adds the shared `file` contract output type to `ContractOutputType`.

## Why
Injectors need a `file` output type to emit **file findings** (e.g. NetExec `spider_plus` enumerating files on SMB shares, or `--ls` on FTP/NFS). The type must exist in this shared package before any injector can declare it, and before the platform can deserialize the contract — otherwise the output is silently dropped at parse time.

This is step 2 of the end-to-end `file` finding work for the attack-path feature (OpenAEV #6647): platform enum → **client-python** → output processor / chaining → injector.

## Change
- `ContractOutputType.File = "file"` in `pyoaev/contracts/contract_config.py`.
- Non-regression test asserting the wire label stays exactly `"file"` (public contract shared with the platform enum).

No behaviour change for existing types.