### PR TITLE
feat(signatures): adding url hash, file hash, source email and target email (#323)

### DIFF
--- a/pyoaev/signatures/types.py
+++ b/pyoaev/signatures/types.py
@@ -59,6 +59,10 @@ class SignatureTypes(str, Enum):
     SIG_TYPE_CLOUD_REGION = "cloud_region"
     SIG_TYPE_TARGET_SERVICE = "target_service"
     SIG_TYPE_QUERY = "query"
+    SIG_TYPE_URL_HASH = "url_hash"
+    SIG_TYPE_FILE_HASH = "file_hash"
+    SIG_TYPE_SOURCE_EMAIL = "source_email"
+    SIG_TYPE_TARGET_EMAIL = "target_email"
     # AI adversarial validation: correlate AI defense (LLM firewall / guardrail) events back to a
     # specific AI inject execution.
     SIG_TYPE_AI_REQUEST_MARKER = "ai_request_marker"

--- a/pyoaev/signatures/types.py
+++ b/pyoaev/signatures/types.py
@@ -63,6 +63,7 @@ class SignatureTypes(str, Enum):
     SIG_TYPE_FILE_HASH = "file_hash"
     SIG_TYPE_SOURCE_EMAIL = "source_email"
     SIG_TYPE_TARGET_EMAIL = "target_email"
+    SIG_TYPE_EMAIL_CUSTOM_HEADER = "email_custom_header"
     # AI adversarial validation: correlate AI defense (LLM firewall / guardrail) events back to a
     # specific AI inject execution.
     SIG_TYPE_AI_REQUEST_MARKER = "ai_request_marker"


### PR DESCRIPTION
### Proposed changes

* Adding `SIG_TYPE_URL_HASH` (instead of `SIG_TYPE_MAIL_URL_HASH`) with a value of `url_hash` to make it more reusable with other injectors/collectors
* Adding `SIG_TYPE_FILE_HASH` (instead of `SIG_TYPE_MAIL_ATTACHMENT_HASH`) with a value of `file_hash` to make it more reusable with other injectors/collectors
* Adding `SIG_TYPE_SOURCE_EMAIL` and `SIG_TYPE_TARGET_EMAIL` with values of `source_email` and `target_email` instead of `SIG_TYPE_MAIL_SOURCE_EMAIL` and `SIG_TYPE_MAIL_PLAYER_EMAIL` to reflect nomenclature used for IP addresses

### Related issues

* Closes #323 