### PR TITLE
feat(client): add action_output contract output type (#331)

### DIFF
--- a/pyoaev/contracts/contract_config.py
+++ b/pyoaev/contracts/contract_config.py
@@ -40,6 +40,7 @@ class ContractFieldKey(str, Enum):
 
 class ContractOutputType(str, Enum):
     Text: str = "text"
+    ActionOutput: str = "action_output"
     Number: str = "number"
     Port: str = "port"
     PortsScan: str = "portscan"

--- a/test/contracts/test_contract_output_types.py
+++ b/test/contracts/test_contract_output_types.py
@@ -10,6 +10,13 @@ class ContractOutputTypeTest(unittest.TestCase):
         self.assertEqual(ContractOutputType.File.value, "file")
         self.assertEqual(ContractOutputType.File, "file")
 
+    def test_action_output_wire_label(self):
+        # The wire label is a public contract shared with the platform enum
+        # (io.openaev.database.model.ContractOutputType.ActionOutput); it must stay
+        # exactly "action_output".
+        self.assertEqual(ContractOutputType.ActionOutput.value, "action_output")
+        self.assertEqual(ContractOutputType.ActionOutput, "action_output")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add `ActionOutput: str = "action_output"` to `ContractOutputType` in `pyoaev/contracts/contract_config.py`, matching the platform's existing `io.openaev.database.model.ContractOutputType.ActionOutput` enum value exactly.
- `ContractOutputElement` already carries a generic `isFindingCompatible: bool` field, so no further class changes are needed — injectors can declare an `action_output` output with `isFindingCompatible=False` right away.
- Add a wire-label stability test mirroring the existing `file` one.

## Motivation

Closes #331. Related to OpenAEV-Platform/injectors#401 (tracking issue for the client-python + netexec migration to action_output). Follow-up from investigating why netexec's contracts (declared `text` output) never produce findings on the platform: `text` findings would show up in the Findings tab, but netexec's raw stdout is only meant to be usable as a chaining/event filter, not a visible finding. The platform already supports this via the `action_output` type + `isFindingCompatible=false` (see `ActionOutputOutputProcessor`); this PR is the client-side prerequisite so netexec (and other injectors) can actually declare it.

## Test plan

- [x] `black --check` / `isort --check-only` / `flake8` on changed files
- [x] `pytest test/contracts` — 8 passed, including the new `test_action_output_wire_label`
