### PR TITLE
chore(pyoaev): compatibility support Python 3.14 (#337)

### DIFF
--- a/pyoaev/base.py
+++ b/pyoaev/base.py
@@ -4,7 +4,16 @@ import json
 import pprint
 import textwrap
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    Optional,
+    Type,
+    Union,
+    get_type_hints,
+)
 
 from pyoaev.exceptions import OpenAEVParsingError
 
@@ -157,7 +166,8 @@ class RESTObject:
         # NOTE(jlvillal): We are creating our managers by looking at the class
         # annotations. If an attribute is annotated as being a *Manager type
         # then we create the manager and assign it to the attribute.
-        for attr, annotation in sorted(self.__annotations__.items()):
+        annotations = get_type_hints(type(self))
+        for attr, annotation in sorted(annotations.items()):
             # We ignore creating a manager for the 'manager' attribute as that
             # is done in the self.__init__() method
             if attr in ("manager",):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.

PR TITLE FORMAT (enforced by CI):
  type(scope?)!?: description (#123)
  - type: feat | fix | chore | docs | style | refactor | perf | test | build | ci | revert
  - scope: optional, e.g. affected module or area
  - description: must start with a lowercase letter
  - (#123): required linked issue number
  Example: feat(client): add bulk export endpoint (#42)
-->

### Proposed changes

* Adapted for Python 3.14: used `get_type_hints(type(self))` instead of `self.__annotations__` to maintain compatibility with the new annotation handling introduced in Python 3.14 and to use the introspection API recommended by Python.


### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #337 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
